### PR TITLE
Add explicit camunda BPM platform version 7.0.0-alpha3 to the README

### DIFF
--- a/order-confirmation-rules/README.md
+++ b/order-confirmation-rules/README.md
@@ -17,7 +17,7 @@ This is a sample for the [camunda BPM platform](http://camunda.org/) on [Java EE
 
 # Getting Started
 
-1. Download the [camunda BPM platform](http://camunda.org/) *for JBoss AS 7* from [here](http://camunda.org/download.html).
+1. Download the [camunda BPM platform](http://camunda.org/) for JBoss AS 7 **(7.0.0-alpha3 or higher)** from [here](http://camunda.org/download.html).
 1. Install it, start it with `<CAMUNDA_BPM_PLATFORM_HOME>/server/jboss-as-7.1.3.Final/bin$ ./standalone.sh`
 1. Make sure JBoss AS 7 is running by pointing your browser to `http://localhost:8080/`
 1. Make sure you have the following installed *and working*:


### PR DESCRIPTION
Since the process engine data source changed in alpha3, the order-confirmation-rules demo will not work in older versions.
