### PR TITLE
Update README with link to Community Hub

### DIFF
--- a/snippets/camunda-modeler-plugins/bpmn-js-plugin-color-picker/README.md
+++ b/snippets/camunda-modeler-plugins/bpmn-js-plugin-color-picker/README.md
@@ -1,12 +1,10 @@
 # BPMN ColorPicker Plugin
 
-A very simple Color Picker as a plugin for the Camunda Modeler.
+## A very simple Color Picker as a plugin for the Camunda Modeler.
 
-## How it looks like
-![Screenshot](screenshot.png)
+### This plugin has moved to a new home in the [Camunda Community Hub](https://github.com/camunda-community-hub/camunda-modeler-plugin-color-picker) and its name has been updated to reflect our [journey from Camunda BPM to Camunda Platform](https://camunda.com/blog/2021/04/the-journey-from-camunda-bpm-to-camunda-platform).
 
-
-## Installation
+### Installation
 Put this directory into the `plugins` directory of the Camunda Modeler and you're ready to go.
 
 If you're interested in how to create your own plugins see the [documentation](https://github.com/camunda/camunda-modeler/tree/547-plugins/docs/plugins) and this [example](https://github.com/camunda/camunda-modeler-plugin-example).

--- a/snippets/camunda-modeler-plugins/bpmn-js-plugin-reduced-palette/README.md
+++ b/snippets/camunda-modeler-plugins/bpmn-js-plugin-reduced-palette/README.md
@@ -1,10 +1,12 @@
 # Camunda Modeler - Reduce Palette
 
+## This plugin has moved to a new home in the [Camunda Community Hub](https://github.com/camunda-community-hub/camunda-modeler-plugin-color-picker) and its name has been updated to reflect our [journey from Camunda BPM to Camunda Platform](https://camunda.com/blog/2021/04/the-journey-from-camunda-bpm-to-camunda-platform).
+
 *Do you need a custom BPMN Symbol palette?*
 
 Then this is the right plugin for you. By default we removed the pool, data objects and the complex gateway from the modeler, but you can extend the plugin and remove more symbols that you don't need.
 
-## Example
+### Example
 
 ![Screenshot 1](screenshot1.png)
 ![Screenshot 2](screenshot2.png)

--- a/snippets/camunda-modeler-plugins/bpmn-js-plugin-reduced-palette/README.md
+++ b/snippets/camunda-modeler-plugins/bpmn-js-plugin-reduced-palette/README.md
@@ -1,6 +1,6 @@
 # Camunda Modeler - Reduce Palette
 
-## This plugin has moved to a new home in the [Camunda Community Hub](https://github.com/camunda-community-hub/camunda-modeler-plugin-color-picker) and its name has been updated to reflect our [journey from Camunda BPM to Camunda Platform](https://camunda.com/blog/2021/04/the-journey-from-camunda-bpm-to-camunda-platform).
+## This plugin has moved to a new home in the [Camunda Community Hub](https://github.com/camunda-community-hub/camunda-modeler-plugin-reduced-palette) and its name has been updated to reflect our [journey from Camunda BPM to Camunda Platform](https://camunda.com/blog/2021/04/the-journey-from-camunda-bpm-to-camunda-platform).
 
 *Do you need a custom BPMN Symbol palette?*
 

--- a/snippets/camunda-modeler-plugins/bpmn-js-plugin-rename-technical-ids/README.md
+++ b/snippets/camunda-modeler-plugins/bpmn-js-plugin-rename-technical-ids/README.md
@@ -1,6 +1,6 @@
 # Camunda Modeler - Rename Technical IDs
 
-## ### This plugin has moved to a new home in the [Camunda Community Hub](https://github.com/camunda-community-hub/camunda-modeler-plugin-rename-technical-ids) and its name has been updated to reflect our [journey from Camunda BPM to Camunda Platform](https://camunda.com/blog/2021/04/the-journey-from-camunda-bpm-to-camunda-platform).
+## This plugin has moved to a new home in the [Camunda Community Hub](https://github.com/camunda-community-hub/camunda-modeler-plugin-rename-technical-ids) and its name has been updated to reflect our [journey from Camunda BPM to Camunda Platform](https://camunda.com/blog/2021/04/the-journey-from-camunda-bpm-to-camunda-platform).
 
 *Have a large BPMN process and want to automate it? Are you annoyed about editing all technical IDs manually?*
 

--- a/snippets/camunda-modeler-plugins/bpmn-js-plugin-rename-technical-ids/README.md
+++ b/snippets/camunda-modeler-plugins/bpmn-js-plugin-rename-technical-ids/README.md
@@ -1,5 +1,7 @@
 # Camunda Modeler - Rename Technical IDs
 
+## ### This plugin has moved to a new home in the [Camunda Community Hub](https://github.com/camunda-community-hub/camunda-modeler-plugin-rename-technical-ids) and its name has been updated to reflect our [journey from Camunda BPM to Camunda Platform](https://camunda.com/blog/2021/04/the-journey-from-camunda-bpm-to-camunda-platform).
+
 *Have a large BPMN process and want to automate it? Are you annoyed about editing all technical IDs manually?*
 
 Then this is the right plugin for you. This plugin helps you to generate and rename technical IDs for all BPMN symbols:

--- a/snippets/camunda-modeler-plugins/camunda-modeler-plugin-usertask-generatedform-preview/README.md
+++ b/snippets/camunda-modeler-plugins/camunda-modeler-plugin-usertask-generatedform-preview/README.md
@@ -1,5 +1,7 @@
 # Camunda Modeler Plugin - UserTask Generated Form Preview and Embedded Form Generator
 
+## This plugin has moved to a new home in the [Camunda Community Hub](https://github.com/camunda-community-hub/camunda-modeler-plugin-usertask-generatedform-preview) and its name has been updated to reflect our [journey from Camunda BPM to Camunda Platform](https://camunda.com/blog/2021/04/the-journey-from-camunda-bpm-to-camunda-platform).
+
 This plugin adds a 'Preview Form' Button to all BPMN User Tasks in the Camunda Modeler Properties Panel.
 Once you click on this button a overlay with show you a preview of your form that has been defined as form fields in the UserTask Forms Tab. It shows you how the form will look like in the default Camunda Tasklist.
 
@@ -7,13 +9,11 @@ Besides just giving you a preview, this plugin automatically generates HTML sour
 
 So this plugin is the perfect fit if you often start with simple generated form fields and then want to make them more advanced by using the embedded forms functionality in the Tasklist.
 
-
-
-## Example
+### Example
 
 ![Plugin Example](plugin-example.gif)
 
-## Installation
+### Installation
 
 Put the whole directory including subdirectories into the `plugins` directory of the Camunda Modeler and you're ready to go.
 


### PR DESCRIPTION
Added link to this plugin's new home in the Community Hub and context as to why its name was changed in the form of a blog post.